### PR TITLE
IMEの変換中にEnterで確定せずに入力すると消える不具合を回避するように

### DIFF
--- a/TVTComment/Model/ChatCollectServiceEntry/NewNiconicoJikkyouChatCollectServiceEntry.cs
+++ b/TVTComment/Model/ChatCollectServiceEntry/NewNiconicoJikkyouChatCollectServiceEntry.cs
@@ -34,7 +34,10 @@ namespace TVTComment.Model.ChatCollectServiceEntry
         {
             if (creationOption != null && !(creationOption is ChatCollectServiceCreationOption))
                 throw new ArgumentException($"Type of {nameof(creationOption)} must be {nameof(NewNiconicoJikkyouChatCollectServiceEntry)}.{nameof(ChatCollectServiceCreationOption)}", nameof(creationOption));
-            return new ChatCollectService.NewNiconicoJikkyouChatCollectService(this, this.liveIdResolver, session.Value);
+            var session = this.session.Value;
+            if (session == null)
+                throw new ChatCollectServiceCreationException("ニコニコ生放送にはニコニコへのログインが必要です");
+            return new ChatCollectService.NewNiconicoJikkyouChatCollectService(this, this.liveIdResolver, session);
         }
     }
 }

--- a/TVTComment/Views/ShellContents/ChatPostControl.xaml
+++ b/TVTComment/Views/ShellContents/ChatPostControl.xaml
@@ -90,7 +90,7 @@
                 </ComboBox.ItemsSource>
             </ComboBox>
             <GridSplitter HorizontalAlignment="Stretch" Grid.Column="1"/>
-            <TextBox Name="PostTextBox" Text="{Binding PostText.Value,UpdateSourceTrigger=PropertyChanged}" ToolTip="コメント (Alt+Enterで改行)" AcceptsReturn="True" Grid.Column="2">
+            <TextBox Name="PostTextBox" Text="{Binding PostText.Value,UpdateSourceTrigger=PropertyChanged,Delay=1}" ToolTip="コメント (Alt+Enterで改行)" AcceptsReturn="True" Grid.Column="2">
                 <i:Interaction.Triggers>
                     <behaviors:ReturnKeyTextBoxTrigger>
                         <i:InvokeCommandAction Command="{Binding PostCommand}"/>


### PR DESCRIPTION
開発ありがとうございます。

IME変換時のTextBoxの動きに不具合があるみたいで、変換中にUpdateSourceTrigger=PropertyChangedが反応してしまうらしく、IMEの変換をEnterで確定せずに次の入力を続けると入力が消える不具合がありました。(ATOK、Microsoft IMEで確認)
この問題はデータバインディングのアップデートを1ミリ秒遅らせることで回避できるようなので、1ミリ秒遅らせてみました。

よろしければお願いいたします。