### PR TITLE
アンカー表記削除などのコメント改変ルールの実装

### DIFF
--- a/TVTComment/Model/ChatModRules/RemoveAnchorChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RemoveAnchorChatModRule.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace TVTComment.Model.ChatModRules
@@ -17,13 +18,15 @@ namespace TVTComment.Model.ChatModRules
 
         public bool Modify(Chat chat)
         {
-            var match = AnchorPattern.Match(chat.Text);
-            if (!match.Success)
+            var matches = AnchorPattern.Matches(chat.Text);
+            if (matches.Count == 0)
             {
                 return false;
             }
 
-            var newText = chat.Text.Replace(match.Value, "").Trim();
+            var newText = matches
+                .Aggregate(chat.Text, (s, match) => s.Replace(match.Value, string.Empty))
+                .Trim();
             chat.SetText(newText);
 
             return true;

--- a/TVTComment/Model/ChatModRules/RemoveAnchorChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RemoveAnchorChatModRule.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace TVTComment.Model.ChatModRules
+{
+    internal class RemoveAnchorChatModRule : IChatModRule
+    {
+        private static readonly Regex AnchorPattern = new Regex(">>\\d+", RegexOptions.Compiled);
+
+        public string Description => "アンカーを削除";
+        public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }
+
+        public RemoveAnchorChatModRule(IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> targetChatCollectServiceEntries)
+        {
+            TargetChatCollectServiceEntries = targetChatCollectServiceEntries;
+        }
+
+        public bool Modify(Chat chat)
+        {
+            var match = AnchorPattern.Match(chat.Text);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            var newText = chat.Text.Replace(match.Value, "").Trim();
+            chat.SetText(newText);
+
+            return true;
+        }
+    }
+}

--- a/TVTComment/Model/ChatModRules/RemoveUrlChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RemoveUrlChatModRule.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TVTComment.Model.ChatModRules
+{
+    internal class RemoveUrlChatModRule : IChatModRule
+    {
+        private static readonly Regex UrlPattern = new Regex(@"http(s)?://([\w-]+\.)+[\w-]+(/[\w- ./?%&=]*)?", RegexOptions.Compiled);
+
+        public string Description => "URL を削除";
+        public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }
+
+        public RemoveUrlChatModRule(IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> targetChatCollectServiceEntries)
+        {
+            TargetChatCollectServiceEntries = targetChatCollectServiceEntries;
+        }
+
+        public bool Modify(Chat chat)
+        {
+            var matches = UrlPattern.Matches(chat.Text);
+            if (matches.Count == 0)
+            {
+                return false;
+            }
+
+            var newText = matches
+                .Aggregate(chat.Text, (s, match) => s.Replace(match.Value, string.Empty))
+                .Trim();
+            chat.SetText(newText);
+
+            return true;
+        }
+    }
+}

--- a/TVTComment/Model/ChatModRules/RenderEmotionAsCommentChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RenderEmotionAsCommentChatModRule.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TVTComment.Model.ChatModRules
+{
+    internal class RenderEmotionAsCommentChatModRule : IChatModRule
+    {
+        private static readonly Regex Pattern = new Regex("^/emotion (?<text>.+)$", RegexOptions.Compiled);
+        private static readonly Regex CountPattern = new Regex(@"/emotion (?<text>.+)×(?<count>\d+)$", RegexOptions.Compiled);
+
+        public string Description => "/emotion コマンドを通常コメントとして描画";
+        public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }
+
+        public RenderEmotionAsCommentChatModRule(IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> targetChatCollectServiceEntries)
+        {
+            TargetChatCollectServiceEntries = targetChatCollectServiceEntries;
+        }
+
+        public bool Modify(Chat chat)
+        {
+            var countMatch = CountPattern.Match(chat.Text);
+            if (countMatch.Success)
+            {
+                var n = int.Parse(countMatch.Groups["count"].Value);
+                var newText = string.Concat(Enumerable.Repeat(countMatch.Groups["text"].Value, n));
+                chat.SetText(newText);
+                return true;
+            }
+
+            var match = Pattern.Match(chat.Text);
+            if (match.Success)
+            {
+                var newText = match.Groups["text"].Value;
+                chat.SetText(newText);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/TVTComment/Model/ChatModRules/RenderInfoAsCommentChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RenderInfoAsCommentChatModRule.cs
@@ -1,0 +1,41 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TVTComment.Model.ChatModRules
+{
+    internal class RenderInfoAsCommentChatModRule : IChatModRule
+    {
+        private static readonly Regex Pattern = new Regex(@"^/info (?<type>\d+) (?<text>.+)$", RegexOptions.Compiled);
+
+        public string Description => "/info コマンドを運営コメントとして描画";
+        public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }
+
+        public RenderInfoAsCommentChatModRule(IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> targetChatCollectServiceEntries)
+        {
+            TargetChatCollectServiceEntries = targetChatCollectServiceEntries;
+        }
+
+        public bool Modify(Chat chat)
+        {
+            var match = Pattern.Match(chat.Text);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            var type = int.Parse(match.Groups["type"].Value);
+            var text = match.Groups["text"].Value;
+
+            // /info 8 第xx位にランクインしました
+            if (type == 8)
+            {
+                chat.SetPosition(Chat.PositionType.Top);
+                chat.SetText(text);
+                return true;
+            }
+
+            return true;
+        }
+    }
+}

--- a/TVTComment/Model/ChatModule.cs
+++ b/TVTComment/Model/ChatModule.cs
@@ -173,6 +173,9 @@ namespace TVTComment.Model
                     case "RemoveUrl":
                         entry.ChatModRule = new ChatModRules.RemoveUrlChatModRule(targetServices);
                         break;
+                    case "RenderEmotionAsComment":
+                        entry.ChatModRule = new ChatModRules.RenderEmotionAsCommentChatModRule(targetServices);
+                        break;
                     case "SetColor":
                         string[] splited = entity.Expression.Split(',');
                         byte[] components = splited.Length == 4
@@ -227,6 +230,8 @@ namespace TVTComment.Model
                     entity.Type = "RemoveAnchor";
                 else if (x.ChatModRule is ChatModRules.RemoveUrlChatModRule)
                     entity.Type = "RemoveUrl";
+                else if (x.ChatModRule is ChatModRules.RenderEmotionAsCommentChatModRule)
+                    entity.Type = "RenderEmotionAsComment";
                 else if(x.ChatModRule is ChatModRules.SetColorChatModRule)
                 {
                     entity.Type = "SetColor";

--- a/TVTComment/Model/ChatModule.cs
+++ b/TVTComment/Model/ChatModule.cs
@@ -170,6 +170,9 @@ namespace TVTComment.Model
                     case "RemoveAnchor":
                         entry.ChatModRule = new ChatModRules.RemoveAnchorChatModRule(targetServices);
                         break;
+                    case "RemoveUrl":
+                        entry.ChatModRule = new ChatModRules.RemoveUrlChatModRule(targetServices);
+                        break;
                     case "SetColor":
                         string[] splited = entity.Expression.Split(',');
                         byte[] components = splited.Length == 4
@@ -222,6 +225,8 @@ namespace TVTComment.Model
                 }
                 else if (x.ChatModRule is ChatModRules.RemoveAnchorChatModRule)
                     entity.Type = "RemoveAnchor";
+                else if (x.ChatModRule is ChatModRules.RemoveUrlChatModRule)
+                    entity.Type = "RemoveUrl";
                 else if(x.ChatModRule is ChatModRules.SetColorChatModRule)
                 {
                     entity.Type = "SetColor";

--- a/TVTComment/Model/ChatModule.cs
+++ b/TVTComment/Model/ChatModule.cs
@@ -176,6 +176,9 @@ namespace TVTComment.Model
                     case "RenderEmotionAsComment":
                         entry.ChatModRule = new ChatModRules.RenderEmotionAsCommentChatModRule(targetServices);
                         break;
+                    case "RenderInfoAsComment":
+                        entry.ChatModRule = new ChatModRules.RenderInfoAsCommentChatModRule(targetServices);
+                        break;
                     case "SetColor":
                         string[] splited = entity.Expression.Split(',');
                         byte[] components = splited.Length == 4
@@ -232,6 +235,8 @@ namespace TVTComment.Model
                     entity.Type = "RemoveUrl";
                 else if (x.ChatModRule is ChatModRules.RenderEmotionAsCommentChatModRule)
                     entity.Type = "RenderEmotionAsComment";
+                else if (x.ChatModRule is ChatModRules.RenderInfoAsCommentChatModRule)
+                    entity.Type = "RenderInfoAsComment";
                 else if(x.ChatModRule is ChatModRules.SetColorChatModRule)
                 {
                     entity.Type = "SetColor";

--- a/TVTComment/Model/ChatModule.cs
+++ b/TVTComment/Model/ChatModule.cs
@@ -60,7 +60,7 @@ namespace TVTComment.Model
             }));
 
             collectServiceModule.NewChatProduced += collectServiceModule_NewChatProduced;
-            
+
             loadSettings();
         }
 
@@ -167,6 +167,9 @@ namespace TVTComment.Model
                             lineCount=2;
                         entry.ChatModRule = new ChatModRules.SmallOnMultiLineChatModRule(targetServices,lineCount);
                         break;
+                    case "RemoveAnchor":
+                        entry.ChatModRule = new ChatModRules.RemoveAnchorChatModRule(targetServices);
+                        break;
                     case "SetColor":
                         string[] splited = entity.Expression.Split(',');
                         byte[] components = splited.Length == 4
@@ -217,6 +220,8 @@ namespace TVTComment.Model
                     entity.Type = "SmallOnMultiLine";
                     entity.Expression = ((ChatModRules.SmallOnMultiLineChatModRule)x.ChatModRule).LineCount.ToString();
                 }
+                else if (x.ChatModRule is ChatModRules.RemoveAnchorChatModRule)
+                    entity.Type = "RemoveAnchor";
                 else if(x.ChatModRule is ChatModRules.SetColorChatModRule)
                 {
                     entity.Type = "SetColor";

--- a/TVTComment/ViewModels/NgSettingWindowViewModel.cs
+++ b/TVTComment/ViewModels/NgSettingWindowViewModel.cs
@@ -83,6 +83,7 @@ namespace TVTComment.ViewModels
         public ICommand AddSmallOnMultiLineRuleCommand { get; private set; }
         public ICommand AddRemoveAnchorCommand { get; private set; }
         public ICommand AddRemoveUrlCommand { get; private set; }
+        public ICommand AddRenderEmotionAsCommentCommand { get; private set; }
         public ICommand AddSetColorRuleCommand { get; private set; }
         public ICommand RemoveRuleCommand { get; private set; }
 
@@ -147,6 +148,11 @@ namespace TVTComment.ViewModels
             AddRemoveUrlCommand = new DelegateCommand(() =>
             {
                 model.ChatModule.AddChatModRule(new Model.ChatModRules.RemoveUrlChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
+            });
+
+            AddRenderEmotionAsCommentCommand = new DelegateCommand(() =>
+            {
+                model.ChatModule.AddChatModRule(new Model.ChatModRules.RenderEmotionAsCommentChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
             });
 
             AddSetColorRuleCommand = new DelegateCommand(() =>

--- a/TVTComment/ViewModels/NgSettingWindowViewModel.cs
+++ b/TVTComment/ViewModels/NgSettingWindowViewModel.cs
@@ -84,6 +84,7 @@ namespace TVTComment.ViewModels
         public ICommand AddRemoveAnchorCommand { get; private set; }
         public ICommand AddRemoveUrlCommand { get; private set; }
         public ICommand AddRenderEmotionAsCommentCommand { get; private set; }
+        public ICommand AddRenderInfoAsCommentCommand { get; private set; }
         public ICommand AddSetColorRuleCommand { get; private set; }
         public ICommand RemoveRuleCommand { get; private set; }
 
@@ -153,6 +154,11 @@ namespace TVTComment.ViewModels
             AddRenderEmotionAsCommentCommand = new DelegateCommand(() =>
             {
                 model.ChatModule.AddChatModRule(new Model.ChatModRules.RenderEmotionAsCommentChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
+            });
+
+            AddRenderInfoAsCommentCommand = new DelegateCommand(() =>
+            {
+                model.ChatModule.AddChatModRule(new Model.ChatModRules.RenderInfoAsCommentChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
             });
 
             AddSetColorRuleCommand = new DelegateCommand(() =>

--- a/TVTComment/ViewModels/NgSettingWindowViewModel.cs
+++ b/TVTComment/ViewModels/NgSettingWindowViewModel.cs
@@ -82,6 +82,7 @@ namespace TVTComment.ViewModels
         public ICommand AddRandomizeColorRuleCommand { get; private set; }
         public ICommand AddSmallOnMultiLineRuleCommand { get; private set; }
         public ICommand AddRemoveAnchorCommand { get; private set; }
+        public ICommand AddRemoveUrlCommand { get; private set; }
         public ICommand AddSetColorRuleCommand { get; private set; }
         public ICommand RemoveRuleCommand { get; private set; }
 
@@ -141,6 +142,11 @@ namespace TVTComment.ViewModels
             AddRemoveAnchorCommand = new DelegateCommand(() =>
             {
                 model.ChatModule.AddChatModRule(new Model.ChatModRules.RemoveAnchorChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
+            });
+
+            AddRemoveUrlCommand = new DelegateCommand(() =>
+            {
+                model.ChatModule.AddChatModRule(new Model.ChatModRules.RemoveUrlChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
             });
 
             AddSetColorRuleCommand = new DelegateCommand(() =>

--- a/TVTComment/ViewModels/NgSettingWindowViewModel.cs
+++ b/TVTComment/ViewModels/NgSettingWindowViewModel.cs
@@ -81,6 +81,7 @@ namespace TVTComment.ViewModels
         public ICommand AddJyougeIroKomeNgCommand { get; private set; }
         public ICommand AddRandomizeColorRuleCommand { get; private set; }
         public ICommand AddSmallOnMultiLineRuleCommand { get; private set; }
+        public ICommand AddRemoveAnchorCommand { get; private set; }
         public ICommand AddSetColorRuleCommand { get; private set; }
         public ICommand RemoveRuleCommand { get; private set; }
 
@@ -136,6 +137,11 @@ namespace TVTComment.ViewModels
               {
                   model.ChatModule.AddChatModRule(new Model.ChatModRules.SmallOnMultiLineChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value),SmallOnMultiLineRuleLineCount.Value));
               });
+
+            AddRemoveAnchorCommand = new DelegateCommand(() =>
+            {
+                model.ChatModule.AddChatModRule(new Model.ChatModRules.RemoveAnchorChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
+            });
 
             AddSetColorRuleCommand = new DelegateCommand(() =>
             {

--- a/TVTComment/Views/NgSettingWindow.xaml
+++ b/TVTComment/Views/NgSettingWindow.xaml
@@ -97,6 +97,7 @@
                             <Button Command="{Binding AddRemoveAnchorCommand}">アンカー削除</Button>
                             <Button Command="{Binding AddRemoveUrlCommand}">URL 削除</Button>
                             <Button Command="{Binding AddRenderEmotionAsCommentCommand}">/emotion をコメントとして描画</Button>
+                            <Button Command="{Binding AddRenderInfoAsCommentCommand}">/info をコメントとして描画</Button>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/TVTComment/Views/NgSettingWindow.xaml
+++ b/TVTComment/Views/NgSettingWindow.xaml
@@ -94,6 +94,7 @@
                                     行以上のコメントsmall化
                                 </TextBlock>
                             </Button>
+                            <Button Command="{Binding AddRemoveAnchorCommand}">アンカー削除</Button>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/TVTComment/Views/NgSettingWindow.xaml
+++ b/TVTComment/Views/NgSettingWindow.xaml
@@ -95,6 +95,7 @@
                                 </TextBlock>
                             </Button>
                             <Button Command="{Binding AddRemoveAnchorCommand}">アンカー削除</Button>
+                            <Button Command="{Binding AddRemoveUrlCommand}">URL 削除</Button>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/TVTComment/Views/NgSettingWindow.xaml
+++ b/TVTComment/Views/NgSettingWindow.xaml
@@ -96,6 +96,7 @@
                             </Button>
                             <Button Command="{Binding AddRemoveAnchorCommand}">アンカー削除</Button>
                             <Button Command="{Binding AddRemoveUrlCommand}">URL 削除</Button>
+                            <Button Command="{Binding AddRenderEmotionAsCommentCommand}">/emotion をコメントとして描画</Button>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>


### PR DESCRIPTION
いつもありがとうございます。

4つ新たに `ChatModRule` を実装しました。
NG 設定ウィンドウにも当該 `ICommand` を実装済です。

- `RemoveAnchorChatModRule`
  アンカー表記 `>>\d+` を削除します。

- `RemoveUrlChatModRule`
  URL 表記を削除します。

- `RenderEmotionAsCommentChatModRule`
  `/emotion` で始まるコメントを通常コメントとして描画します。  
  `/emotion !?` は `!?` として描画されます。  
  `/emotion ♡x3` は `♡♡♡` として描画されます。

- `RenderInfoAsCommentChatModRule`
  `/info` で始まる運営コメントを通常コメントとして描画します。  
  `/info 8 第xx位にランクインしました` は上部に `第xx位にランクインしました` として描画されます。

マージの方ご検討よろしくおねがいします。

![image](https://user-images.githubusercontent.com/7302150/104085878-1b359300-5296-11eb-9eec-df2a69c04669.png)