### PR TITLE
getplayerstatus廃止につき別APIへ変更

### DIFF
--- a/TVTComment/Model/ChatCollectService/NewNiconicoJikkyouChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/NewNiconicoJikkyouChatCollectService.cs
@@ -177,9 +177,9 @@ namespace TVTComment.Model.ChatCollectService
             if (!playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("OK"))
             {
                 if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("SERVER_ERROR"))
-                    throw new ChatReceivingException("ニコニコのサーバがメンテナンス中の可能性があります");
+                    throw new ChatReceivingException("ニコニコのサーバーがメンテナンス中の可能性があります");
                 if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("INTERNAL_SERVER_ERROR"))
-                    throw new ChatReceivingException("ニコニコのサーバで内部エラーが発生しました");
+                    throw new ChatReceivingException("ニコニコのサーバーで内部エラーが発生しました");
                 if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("NOT_FOUND"))
                     throw new LiveNotFoundChatReceivingException(); // 呼び出し側で特別な処理をするので別の例外を投げて区別する
                 throw new ChatReceivingException("コメントサーバーから予期しないPlayerStatusが返されました:\n" + playerStatusStr);

--- a/TVTComment/Model/ChatCollectService/NewNiconicoJikkyouChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/NewNiconicoJikkyouChatCollectService.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
-using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 
 namespace TVTComment.Model.ChatCollectService
 {
@@ -100,7 +100,7 @@ namespace TVTComment.Model.ChatCollectService
 
             string originalLiveId = this.liveIdResolver.Resolve(channel.NetworkId, channel.ServiceId);
 
-            if(originalLiveId != this.originalLiveId)
+            if (originalLiveId != this.originalLiveId)
             {
                 // 生放送IDが変更になった場合
 
@@ -119,7 +119,7 @@ namespace TVTComment.Model.ChatCollectService
                 this.commentTagQueue.Clear();
                 this.notOnAir = false;
 
-                if(this.originalLiveId != "")
+                if (this.originalLiveId != "")
                 {
                     this.cancellationTokenSource = new CancellationTokenSource();
                     chatCollectTask = collectChat(originalLiveId, this.cancellationTokenSource.Token);
@@ -141,7 +141,7 @@ namespace TVTComment.Model.ChatCollectService
             var ret = new List<Chat>();
             while (this.commentTagQueue.TryDequeue(out var tag))
             {
-                switch(tag)
+                switch (tag)
                 {
                     case NiconicoUtils.ChatNiconicoCommentXmlTag chatTag:
                         ret.Add(NiconicoUtils.ChatNiconicoCommentXmlTagToChat.Convert(chatTag));
@@ -153,29 +153,39 @@ namespace TVTComment.Model.ChatCollectService
 
         private async Task collectChat(string originalLiveId, CancellationToken cancellationToken)
         {
-            string playerStatusStr;
+            Stream playerStatusStr;
             try
             {
-                playerStatusStr = await this.httpClient.GetStringAsync($"http://live.nicovideo.jp/api/getplayerstatus/{originalLiveId}").ConfigureAwait(false);
+                if (!originalLiveId.StartsWith("lv")) // 代替えAPIではコミュニティ・チャンネルにおけるコメント鯖取得ができないのでlvを取得しに行く
+                {
+                    var getLiveId = await this.httpClient.GetStreamAsync($"https://live2.nicovideo.jp/unama/tool/v1/broadcasters/social_group/{originalLiveId}/program").ConfigureAwait(false);
+                    var liveIdJson = await JsonDocument.ParseAsync(getLiveId, cancellationToken: cancellationToken).ConfigureAwait(false);
+                    var liveIdRoot = liveIdJson.RootElement;
+                    if (!liveIdRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("OK")) throw new ChatReceivingException("コミュニティ・チャンネルが見つかりませんでした");
+                    originalLiveId = liveIdRoot.GetProperty("data").GetProperty("nicoliveProgramId").GetString(); // lvから始まるLiveIDに置き換え
+
+                }
+                playerStatusStr = await this.httpClient.GetStreamAsync($"https://live2.nicovideo.jp/unama/watch/{originalLiveId}/programinfo").ConfigureAwait(false);
             }
             catch (HttpRequestException e)
             {
                 throw new ChatReceivingException("サーバーとの通信でエラーが発生しました", e);
             }
-            var playerStatus = XDocument.Parse(playerStatusStr).Root;
+            var playerStatus = await JsonDocument.ParseAsync(playerStatusStr, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var playerStatusRoot = playerStatus.RootElement;
 
-            if (playerStatus.Attribute("status").Value != "ok")
+            if (!playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("OK"))
             {
-                if (playerStatus.Element("error")?.Element("code")?.Value == "comingsoon")
-                    throw new ChatReceivingException("放送開始前です");
-                if (playerStatus.Element("error")?.Element("code")?.Value == "closed")
-                    throw new LiveClosedChatReceivingException(); // 呼び出し側で特別な処理をするので別の例外を投げて区別する
-                if (playerStatus.Element("error")?.Element("code")?.Value == "notfound")
+                if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("SERVER_ERROR"))
+                    throw new ChatReceivingException("ニコニコのサーバがメンテナンス中の可能性があります");
+                if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("INTERNAL_SERVER_ERROR"))
+                    throw new ChatReceivingException("ニコニコのサーバで内部エラーが発生しました");
+                if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("NOT_FOUND"))
                     throw new LiveNotFoundChatReceivingException(); // 呼び出し側で特別な処理をするので別の例外を投げて区別する
                 throw new ChatReceivingException("コメントサーバーから予期しないPlayerStatusが返されました:\n" + playerStatusStr);
             }
 
-            this.liveId = playerStatus.Element("stream").Element("id").Value;
+            this.liveId = playerStatusRoot.GetProperty("data").GetProperty("socialGroup").GetProperty("id").GetString();
 
             try
             {

--- a/TVTComment/Model/ChatCollectService/NiconicoLiveChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/NiconicoLiveChatCollectService.cs
@@ -139,9 +139,9 @@ namespace TVTComment.Model.ChatCollectService
             if (!playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("OK"))
             {
                 if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("SERVER_ERROR"))
-                    throw new ChatReceivingException("ニコニコのサーバがメンテナンス中の可能性があります");
+                    throw new ChatReceivingException("ニコニコのサーバーがメンテナンス中の可能性があります");
                 if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("INTERNAL_SERVER_ERROR"))
-                    throw new ChatReceivingException("ニコニコのサーバで内部エラーが発生しました");
+                    throw new ChatReceivingException("ニコニコのサーバーで内部エラーが発生しました");
                 if (playerStatusRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("NOT_FOUND"))
                     throw new ChatReceivingException("放送が見つかりませんでした");
                 throw new ChatReceivingException("コメントサーバーから予期しないPlayerStatusが返されました:\n" + playerStatusStr);

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -92,6 +92,9 @@ namespace TVTComment.Model.NiconicoUtils
                 var playerStatus = await JsonDocument.ParseAsync(str, cancellationToken: cancellationToken).ConfigureAwait(false);
                 var playerStatusRoot = playerStatus.RootElement;
 
+                if (playerStatusRoot.GetProperty("data").GetProperty("rooms").GetArrayLength() >= 0)
+                    throw new InvalidPlayerStatusNicoLiveCommentReceiverException("現在放送されていないか、コミュニティ限定配信のためコメント取得できませんでした");
+
                 var threadId = playerStatusRoot.GetProperty("data").GetProperty("rooms")[0].GetProperty("threadId").GetString();
                 var msUriStr = playerStatusRoot.GetProperty("data").GetProperty("rooms")[0].GetProperty("xmlSocketUri").GetString();
                 if (threadId == null || msUriStr == null)

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -92,7 +92,7 @@ namespace TVTComment.Model.NiconicoUtils
                 var playerStatus = await JsonDocument.ParseAsync(str, cancellationToken: cancellationToken).ConfigureAwait(false);
                 var playerStatusRoot = playerStatus.RootElement;
 
-                if (playerStatusRoot.GetProperty("data").GetProperty("rooms").GetArrayLength() >= 0)
+                if (playerStatusRoot.GetProperty("data").GetProperty("rooms").GetArrayLength() <= 0)
                     throw new InvalidPlayerStatusNicoLiveCommentReceiverException("現在放送されていないか、コミュニティ限定配信のためコメント取得できませんでした");
 
                 var threadId = playerStatusRoot.GetProperty("data").GetProperty("rooms")[0].GetProperty("threadId").GetString();

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -3,11 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http;
 using System.Net.Sockets;
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 
 namespace TVTComment.Model.NiconicoUtils
 {
@@ -43,7 +44,7 @@ namespace TVTComment.Model.NiconicoUtils
     class NicoLiveCommentReceiver : IDisposable
     {
         public NiconicoLoginSession NiconicoLoginSession { get; }
-        
+
         public NicoLiveCommentReceiver(NiconicoLoginSession niconicoLoginSession)
         {
             this.NiconicoLoginSession = niconicoLoginSession;
@@ -51,6 +52,9 @@ namespace TVTComment.Model.NiconicoUtils
             var handler = new HttpClientHandler();
             handler.CookieContainer.Add(niconicoLoginSession.Cookie);
             this.httpClient = new HttpClient(handler);
+            var assembly = Assembly.GetExecutingAssembly().GetName();
+            var ua = assembly.Name + "/" + assembly.Version.ToString(3);
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", ua);
         }
 
         /// <summary>
@@ -60,19 +64,19 @@ namespace TVTComment.Model.NiconicoUtils
         /// <exception cref="InvalidPlayerStatusNicoLiveCommentReceiverException"></exception>
         /// <exception cref="NetworkNicoLiveCommentReceiverException"></exception>
         /// <exception cref="ConnectionClosedNicoLiveCommentReceiverException"></exception>
-        public async IAsyncEnumerable<NiconicoCommentXmlTag> Receive(string liveId, [EnumeratorCancellation]CancellationToken cancellationToken)
+        public async IAsyncEnumerable<NiconicoCommentXmlTag> Receive(string liveId, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
-            using var _  = cancellationToken.Register(() =>
+            using var _ = cancellationToken.Register(() =>
             {
                 this.httpClient.CancelPendingRequests();
             });
 
             for (int disconnectedCount = 0; disconnectedCount < 5; ++disconnectedCount)
             {
-                string str;
+                Stream str;
                 try
                 {
-                    str = await this.httpClient.GetStringAsync($"http://live.nicovideo.jp/api/getplayerstatus/{liveId}").ConfigureAwait(false);
+                    str = await this.httpClient.GetStreamAsync($"https://live2.nicovideo.jp/unama/watch/{liveId}/programinfo").ConfigureAwait(false);
                 }
                 // httpClient.CancelPendingRequestsが呼ばれた、もしくはタイムアウト
                 catch (TaskCanceledException e)
@@ -81,21 +85,21 @@ namespace TVTComment.Model.NiconicoUtils
                         throw new OperationCanceledException(null, e, cancellationToken);
                     throw new NetworkNicoLiveCommentReceiverException(e);
                 }
-                catch(HttpRequestException e)
+                catch (HttpRequestException e)
                 {
                     throw new NetworkNicoLiveCommentReceiverException(e);
                 }
-                var playerStatus = XDocument.Parse(str).Root;
+                var playerStatus = await JsonDocument.ParseAsync(str, cancellationToken: cancellationToken).ConfigureAwait(false);
+                var playerStatusRoot = playerStatus.RootElement;
 
-                string threadId = playerStatus.Element("ms")?.Element("thread")?.Value;
-                string ms = playerStatus.Element("ms")?.Element("addr")?.Value;
-                string msPort = playerStatus.Element("ms")?.Element("port")?.Value;
-                if(threadId == null || ms == null || msPort == null)
+                var threadId = playerStatusRoot.GetProperty("data").GetProperty("rooms")[0].GetProperty("threadId").GetString();
+                var msUriStr = playerStatusRoot.GetProperty("data").GetProperty("rooms")[0].GetProperty("xmlSocketUri").GetString();
+                if (threadId == null || msUriStr == null)
                 {
-                    throw new InvalidPlayerStatusNicoLiveCommentReceiverException(str);
+                    throw new InvalidPlayerStatusNicoLiveCommentReceiverException(str.ToString());
                 }
-
-                using var tcpClinet = new TcpClient(ms, int.Parse(msPort));
+                var msUri = new Uri(msUriStr);
+                using var tcpClinet = new TcpClient(msUri.Host, msUri.Port);
                 var socketStream = tcpClinet.GetStream();
                 using var socketReader = new StreamReader(socketStream, Encoding.UTF8);
 
@@ -110,7 +114,7 @@ namespace TVTComment.Model.NiconicoUtils
                 {
                     await socketStream.WriteAsync(bodyEncoded, 0, bodyEncoded.Length, cancellationToken).ConfigureAwait(false);
                 }
-                catch(Exception e) when(e is ObjectDisposedException || e is SocketException || e is IOException)
+                catch (Exception e) when (e is ObjectDisposedException || e is SocketException || e is IOException)
                 {
                     if (cancellationToken.IsCancellationRequested)
                         throw new OperationCanceledException(null, e, cancellationToken);
@@ -142,7 +146,7 @@ namespace TVTComment.Model.NiconicoUtils
                         break; // 4時リセットかもしれない→もう一度試す
 
                     this.parser.Push(new string(buf[..receivedByte]));
-                    while(this.parser.DataAvailable())
+                    while (this.parser.DataAvailable())
                         yield return this.parser.Pop();
                 }
             }

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentSender.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentSender.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
+using System.Reflection;
 using System.Text;
 using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Unicode;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 
 namespace TVTComment.Model.NiconicoUtils
 {
@@ -60,6 +61,9 @@ namespace TVTComment.Model.NiconicoUtils
             var handler = new HttpClientHandler();
             handler.CookieContainer.Add(niconicoSession.Cookie);
             this.httpClient = new HttpClient(handler);
+            var assembly = Assembly.GetExecutingAssembly().GetName();
+            var ua = assembly.Name + "/" + assembly.Version.ToString(3);
+            httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", ua);
         }
 
         /// <summary>
@@ -71,26 +75,36 @@ namespace TVTComment.Model.NiconicoUtils
         /// <exception cref="ResponseErrorNicoLiveCommentSenderException"></exception>
         public async Task Send(string liveId, string message, string mail)
         {
-            string str;
+            Stream str;
             try
             {
-                str = await this.httpClient.GetStringAsync($"http://live.nicovideo.jp/api/getplayerstatus/{liveId}");
+                if (!liveId.StartsWith("lv")) // 代替えAPIではコミュニティ・チャンネルにおけるコメント鯖取得ができないのでlvを取得しに行く
+                {
+                    var getLiveId = await httpClient.GetStreamAsync($"https://live2.nicovideo.jp/unama/tool/v1/broadcasters/social_group/{liveId}/program").ConfigureAwait(false);
+                    var liveIdJson = await JsonDocument.ParseAsync(getLiveId).ConfigureAwait(false);
+                    var liveIdRoot = liveIdJson.RootElement;
+                    if (!liveIdRoot.GetProperty("meta").GetProperty("errorCode").GetString().Equals("OK")) throw new InvalidPlayerStatusNicoLiveCommentSenderException("コミュニティ・チャンネルが見つかりませんでした");
+                    liveId = liveIdRoot.GetProperty("data").GetProperty("nicoliveProgramId").GetString(); // lvから始まるLiveIDに置き換え
+
+                }
+                str = await this.httpClient.GetStreamAsync($"https://live2.nicovideo.jp/unama/watch/{liveId}/programinfo").ConfigureAwait(false);
             }
             catch(HttpRequestException e)
             {
                 throw new NetworkNicoLiveCommentSenderException(e);
             }
 
-            var playerStatus = XDocument.Parse(str).Root;
+            var playerStatus = await JsonDocument.ParseAsync(str).ConfigureAwait(false);
+            var playerStatusRoot = playerStatus.RootElement;
 
-            liveId = playerStatus.Element("stream")?.Element("id")?.Value;
-            string openTime = playerStatus.Element("stream")?.Element("open_time")?.Value;
-            if(liveId == null || openTime == null)
+            playerStatusRoot.GetProperty("data").GetProperty("beginAt").TryGetInt64(out long openTime);
+
+            if(liveId == null || openTime == 0)
             {
-                throw new InvalidPlayerStatusNicoLiveCommentSenderException(str);
+                throw new InvalidPlayerStatusNicoLiveCommentSenderException(playerStatus.ToString());
             }
             // vposは10ミリ秒単位
-            long vpos = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 10 - long.Parse(openTime) * 100;
+            long vpos = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 10 - openTime * 100;
 
             var options = new JsonSerializerOptions
             {


### PR DESCRIPTION
開発ありがとうございます。

1月20日付けでUA無しでのgetplayerstatusへのリクエストが廃止されました。
また同APIは2月26日付けで廃止とのことです。

その為別のAPIにて該当機能を実装しましたのでよろしければマージお願い致します。
