### PR TITLE
ニコニコ動画のログインセッションを設定ファイルに保持

### DIFF
--- a/TVTComment/Model/ChatCollectService/NiconicoLiveChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/NiconicoLiveChatCollectService.cs
@@ -48,6 +48,7 @@ namespace TVTComment.Model.ChatCollectService
         private readonly NiconicoUtils.NicoLiveCommentSender commentSender;
         private DateTime lastHeartbeatTime = DateTime.MinValue;
         private readonly CancellationTokenSource cancel = new CancellationTokenSource();
+        private NiconicoUtils.NiconicoLoginSession session;
 
         public NiconicoLiveChatCollectService(
             ChatCollectServiceEntry.IChatCollectServiceEntry serviceEntry, string liveId,
@@ -56,6 +57,7 @@ namespace TVTComment.Model.ChatCollectService
         {
             this.ServiceEntry = serviceEntry;
             this.originalLiveId = liveId;
+            this.session = session;
 
             var assembly = Assembly.GetExecutingAssembly().GetName();
             var ua = assembly.Name + "/" + assembly.Version.ToString(3);
@@ -131,6 +133,8 @@ namespace TVTComment.Model.ChatCollectService
             }
             catch (HttpRequestException e)
             {
+                if (e.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                    this.session.BadSession = true;
                 throw new ChatReceivingException("サーバーとの通信でエラーが発生しました", e);
             }
             var playerStatus = await JsonDocument.ParseAsync(playerStatusStr, cancellationToken: cancel).ConfigureAwait(false);

--- a/TVTComment/ViewModels/SettingsWindowViewModel.cs
+++ b/TVTComment/ViewModels/SettingsWindowViewModel.cs
@@ -15,6 +15,9 @@ namespace TVTComment.ViewModels
         public ObservableValue<string> NiconicoLoginStatus { get; } = new ObservableValue<string>();
         public ObservableValue<string> NiconicoUserId { get; } = new ObservableValue<string>();
         public ObservableValue<string> NiconicoPassword { get; } = new ObservableValue<string>();
+        public ObservableValue<string> NiconicoSid { get; } = new ObservableValue<string>();
+        public ObservableValue<string> NiconicoSession { get; } = new ObservableValue<string>();
+        public ObservableValue<string> NiconicoSecure { get; } = new ObservableValue<string>();
         public ObservableValue<string> NichanResCollectInterval { get; } = new ObservableValue<string>();
         public ObservableValue<string> NichanThreadSearchInterval { get; } = new ObservableValue<string>();
         public ObservableValue<string> NichanApiHmKey { get; } = new ObservableValue<string>();
@@ -52,7 +55,7 @@ namespace TVTComment.ViewModels
 
                   try
                   {
-                      await niconico.SetUser(NiconicoUserId.Value, NiconicoPassword.Value);
+                      await niconico.SetUser(NiconicoUserId.Value, NiconicoPassword.Value, NiconicoSid.Value, NiconicoSession.Value, NiconicoSecure.Value);
                       syncNiconicoUserStatus();
                   }
                   catch (Model.NiconicoUtils.NiconicoLoginSessionException)
@@ -97,6 +100,9 @@ namespace TVTComment.ViewModels
             NiconicoLoginStatus.Value = niconico.IsLoggedin ? "ログイン済" : "未ログイン";
             NiconicoUserId.Value = niconico.UserId;
             NiconicoPassword.Value = niconico.UserPassword;
+            NiconicoSid.Value = niconico.NicoSid;
+            NiconicoSession.Value = niconico.Session;
+            NiconicoSecure.Value = niconico.SessionSecure;
         }
 
         private void syncNichanSettings()


### PR DESCRIPTION
プラグインの有効無効のたびに新規でログインセッションを取得していたのを、設定ファイルに保持して再利用できるようにしました。
また、再利用したセッションキーでAPIサーバーから401が返ってきたら無効化されるようになっています。