### PR TITLE
削除されたコメがあると不正な応答で過去ログ取得できないのを修正

### DIFF
--- a/TVTComment/Model/ChatCollectService/TsukumijimaJikkyoApiChatCollectService.cs
+++ b/TVTComment/Model/ChatCollectService/TsukumijimaJikkyoApiChatCollectService.cs
@@ -177,6 +177,9 @@ namespace TVTComment.Model.ChatCollectService
 
                     if (threadNoList.Contains((thread, no))) // 同じスレッドの同じコメ番があればスキップ
                         continue;
+                    
+                    if (chatObj.TryGetProperty("deleted", out _)) //削除済みの場合スキップ
+                        continue;
 
                     int vpos = int.Parse(chatObj.GetProperty("vpos").GetString());
                     long date = int.Parse(chatObj.GetProperty("date").GetString());

--- a/TVTComment/Model/Nichan/DatParser.cs
+++ b/TVTComment/Model/Nichan/DatParser.cs
@@ -129,14 +129,14 @@ namespace Nichan
         private int resNum;
         private bool isBeforeFirstLine;
 
-        private static readonly Regex reDate = new Regex(@"(\d+)/(\d+)/(\d+)[^ ]* (\d+):(\d+):(\d+)\.(\d+)");
+        private static readonly Regex reDate = new Regex(@"(\d+)/(\d+)/(\d+)[^ ]* (\d+):(\d+):(\d+)(\.(?<sec>\d+)| )");
         private static DateTime? getDate(string str)
         {
             Match m = reDate.Match(str);
             if (m.Success)
                 return new DateTime(
                     int.Parse(m.Groups[1].Value), int.Parse(m.Groups[2].Value), int.Parse(m.Groups[3].Value),
-                    int.Parse(m.Groups[4].Value), int.Parse(m.Groups[5].Value), int.Parse(m.Groups[6].Value), int.Parse(m.Groups[7].Value) * 10, DateTimeKind.Local
+                    int.Parse(m.Groups[4].Value), int.Parse(m.Groups[5].Value), int.Parse(m.Groups[6].Value), m.Groups["sec"].Success ? int.Parse(m.Groups["sec"].Value) * 10 : 0, DateTimeKind.Local
                 );
             else
                 return null;


### PR DESCRIPTION
旧実況からニコ生になった影響で、タイムシフトでコメントが削除されているケースがあるようです。
その場合、非公式過去ログには削除済みのchatが残っていてTvTCommentでそのchatをパースできず不正な応答となるようなので修正しました。
あと、2ch過去ログにおいて日時に秒がないデータが存在していたため考慮するように変更しました。