### PR TITLE
JSONWebSocket仕様の新ニコ実況に対応

### DIFF
--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -143,7 +143,9 @@ namespace TVTComment.Model.NiconicoUtils
                 // WebSocketAPIに接続
                 ClientWebSocket ws = new ClientWebSocket();
                 // UAヘッダ追加
-                ws.Options.SetRequestHeader("User-Agent", WEBSOCKET_CLIENT_UA);
+                var assembly = Assembly.GetExecutingAssembly().GetName();
+                string version = assembly.Version.ToString(3);
+                ws.Options.SetRequestHeader("User-Agent", $"TvtComment/{version}");
                 // SubProtocol追加
                 ws.Options.AddSubProtocol(WEBSOCKET_PROTOCOL);
                 // Sec-WebSocket-Versionヘッダ追加
@@ -227,7 +229,6 @@ namespace TVTComment.Model.NiconicoUtils
 
         private readonly HttpClient httpClient;
         private readonly NiconicoCommentJsonParser parser = new NiconicoCommentJsonParser(true);
-        private readonly string WEBSOCKET_CLIENT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36";
         private readonly string WEBSOCKET_PROTOCOL = "msg.nicovideo.jp#json";
         private readonly string WEBSOCKET_EXTENSIONS = "permessage-deflate; client_max_window_bits";
     }

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -110,8 +110,8 @@ namespace TVTComment.Model.NiconicoUtils
                 ClientWebSocket ws = new ClientWebSocket();
                 // UAヘッダ追加
                 ws.Options.SetRequestHeader("User-Agent", WEBSOCKET_CLIENT_UA);
-                // Sec-WebSocket-Protocolヘッダ追加
-                ws.Options.SetRequestHeader("Sec-WebSocket-Protocol", WEBSOCKET_PROTOCOL);
+                // SubProtocol追加
+                ws.Options.AddSubProtocol(WEBSOCKET_PROTOCOL);
                 // Sec-WebSocket-Versionヘッダ追加
                 ws.Options.SetRequestHeader("Sec-WebSocket-Extensions", WEBSOCKET_EXTENSIONS);
 

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -102,14 +102,13 @@ namespace TVTComment.Model.NiconicoUtils
                 {
                     throw new InvalidPlayerStatusNicoLiveCommentReceiverException(str.ToString());
                 }
+                // WebSocketAPIに接続
                 ClientWebSocket ws = new ClientWebSocket();
                 var uri = new Uri(msUriStr);
-
-                //サーバに対し、接続を開始
                 await ws.ConnectAsync(uri, cancellationToken);
                 var buffer = new byte[1024];
-
-                string body= "[{\"ping\":{\"content\":\"rs:0\"}},{\"ping\":{\"content\":\"ps:0\"}},{\"thread\":{\"thread\":\"" + threadId + "\",\"version\":\"20061206\",\"user_id\":\"guest\",\"res_from\":-10,\"with_global\":1,\"scores\":1,\"nicoru\":0}},{\"ping\":{\"content\":\"pf:0\"}},{\"ping\":{\"content\":\"rf:0\"}}]";
+                // threadId情報を送信
+                string body = "[{\"ping\":{\"content\":\"rs:0\"}},{\"ping\":{\"content\":\"ps:0\"}},{\"thread\":{\"thread\":\"" + threadId + "\",\"version\":\"20061206\",\"user_id\":\"guest\",\"res_from\":-10,\"with_global\":1,\"scores\":1,\"nicoru\":0}},{\"ping\":{\"content\":\"pf:0\"}},{\"ping\":{\"content\":\"rf:0\"}}]";
                 byte[] bodyEncoded = Encoding.UTF8.GetBytes(body);
                 try
                 {
@@ -153,7 +152,7 @@ namespace TVTComment.Model.NiconicoUtils
                         if (count >= buffer.Length)
                         {
                             await ws.CloseAsync(WebSocketCloseStatus.InvalidPayloadData,
-                              "That's too long", CancellationToken.None);
+                              "That's too long", cancellationToken);
                             throw new ConnectionClosedNicoLiveCommentReceiverException();
                         }
                         segment = new ArraySegment<byte>(buffer, count, buffer.Length - count);

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -74,6 +74,10 @@ namespace TVTComment.Model.NiconicoUtils
 
             for (int disconnectedCount = 0; disconnectedCount < 5; ++disconnectedCount)
             {
+                // 万が一接続中断した場合、数秒空いたからリトライする。
+                var random = new Random();
+                await Task.Delay((disconnectedCount * 5000) + random.Next(0, 101));
+
                 Stream str;
                 try
                 {

--- a/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
+++ b/TVTComment/Model/NiconicoUtils/NicoLiveCommentReceiver.cs
@@ -104,9 +104,17 @@ namespace TVTComment.Model.NiconicoUtils
                 }
                 // WebSocketAPIに接続
                 ClientWebSocket ws = new ClientWebSocket();
+                // UAヘッダ追加
+                ws.Options.SetRequestHeader("User-Agent", WEBSOCKET_CLIENT_UA);
+                // Sec-WebSocket-Protocolヘッダ追加
+                ws.Options.SetRequestHeader("Sec-WebSocket-Protocol", WEBSOCKET_PROTOCOL);
+                // Sec-WebSocket-Versionヘッダ追加
+                ws.Options.SetRequestHeader("Sec-WebSocket-Extensions", WEBSOCKET_EXTENSIONS);
+
                 var uri = new Uri(msUriStr);
                 await ws.ConnectAsync(uri, cancellationToken);
                 var buffer = new byte[1024];
+
                 // threadId情報を送信
                 string body = "[{\"ping\":{\"content\":\"rs:0\"}},{\"ping\":{\"content\":\"ps:0\"}},{\"thread\":{\"thread\":\"" + threadId + "\",\"version\":\"20061206\",\"user_id\":\"guest\",\"res_from\":-10,\"with_global\":1,\"scores\":1,\"nicoru\":0}},{\"ping\":{\"content\":\"pf:0\"}},{\"ping\":{\"content\":\"rf:0\"}}]";
                 byte[] bodyEncoded = Encoding.UTF8.GetBytes(body);
@@ -178,5 +186,8 @@ namespace TVTComment.Model.NiconicoUtils
 
         private readonly HttpClient httpClient;
         private readonly NiconicoCommentJsonParser parser = new NiconicoCommentJsonParser(true);
+        private readonly string WEBSOCKET_CLIENT_UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.90 Safari/537.36";
+        private readonly string WEBSOCKET_PROTOCOL = "msg.nicovideo.jp#json";
+        private readonly string WEBSOCKET_EXTENSIONS = "permessage-deflate; client_max_window_bits";
     }
 }

--- a/TVTComment/Model/NiconicoUtils/NiconicoCommentJsonParser.cs
+++ b/TVTComment/Model/NiconicoUtils/NiconicoCommentJsonParser.cs
@@ -60,7 +60,7 @@ namespace TVTComment.Model.NiconicoUtils
         private static ChatNiconicoCommentXmlTag getChatJSONTag(string str) {
             JObject jsonObj = JObject.Parse(str);
 
-            int vpos = int.Parse(jsonObj["chat"]["vpos"].ToString());
+            int vpos = jsonObj["chat"]["vpos"] == null ? 0 : int.Parse(jsonObj["chat"]["vpos"].ToString()); //ニコ生側の不具合で稀に必須項目のvposが抜けてるデータが流れてくる可能性があるので念の為JSONキー確認する。
             long date = long.Parse(jsonObj["chat"]["date"].ToString());
             int dateUsec = jsonObj["chat"]["date_usec"] == null ? 0 : int.Parse(jsonObj["chat"]["date_usec"].ToString());
             string mail = jsonObj["chat"]["mail"] == null ? "" : jsonObj["chat"]["mail"].ToString();

--- a/TVTComment/Model/NiconicoUtils/NiconicoCommentJsonParser.cs
+++ b/TVTComment/Model/NiconicoUtils/NiconicoCommentJsonParser.cs
@@ -10,7 +10,7 @@ namespace TVTComment.Model.NiconicoUtils
         private string buffer;
 
         /// <summary>
-        /// <see cref="NiconicoCommentXmlParser"/>を初期化する
+        /// <see cref="NiconicoCommentJsonParser"/>を初期化する
         /// </summary>
         /// <param name="socketFormat">ソケットを使うリアルタイムのデータ形式ならtrue 過去ログなどのデータ形式ならfalse</param>
         public NiconicoCommentJsonParser(bool socketFormat)
@@ -22,6 +22,7 @@ namespace TVTComment.Model.NiconicoUtils
         {
             if (socketFormat)
             {
+               // 一旦、コメント関連データのみ解析する
                if (str.StartsWith("{\"chat"))
                {
                    chats.Enqueue(getChatJSONTag(str));
@@ -58,7 +59,7 @@ namespace TVTComment.Model.NiconicoUtils
 
         private static ChatNiconicoCommentXmlTag getChatJSONTag(string str) {
             JObject jsonObj = JObject.Parse(str);
-            // {"chat":{"thread":"M.kk-tzPBrneGMsNfDNO1skg","no":45929,"vpos":6496293,"date":1616936565,"date_usec":664450,"mail":"184","user_id":"EvrCRqk2e04B-pYS7q44kVU5HR4","anonymity":1,"content":"結局SBの勝ちかいｗ"}}
+
             int vpos = int.Parse(jsonObj["chat"]["vpos"].ToString());
             long date = long.Parse(jsonObj["chat"]["date"].ToString());
             int dateUsec = jsonObj["chat"]["date_usec"] == null ? 0 : int.Parse(jsonObj["chat"]["date_usec"].ToString());
@@ -69,6 +70,7 @@ namespace TVTComment.Model.NiconicoUtils
             int abone = jsonObj["chat"]["abone"] == null ? 0 : int.Parse(jsonObj["chat"]["abone"].ToString());
             string content = (string)jsonObj["chat"]["content"];
             int no = int.Parse(jsonObj["chat"]["no"].ToString());
+
             return new ChatNiconicoCommentXmlTag(
                         content, 0, no, vpos, date, dateUsec, mail, userId, premium, anonymity, abone
                     );

--- a/TVTComment/Model/NiconicoUtils/NiconicoCommentJsonParser.cs
+++ b/TVTComment/Model/NiconicoUtils/NiconicoCommentJsonParser.cs
@@ -1,0 +1,77 @@
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+
+namespace TVTComment.Model.NiconicoUtils
+{
+    class NiconicoCommentJsonParser
+    {
+        private bool socketFormat;
+        private Queue<NiconicoCommentXmlTag> chats = new Queue<NiconicoCommentXmlTag>();
+        private string buffer;
+
+        /// <summary>
+        /// <see cref="NiconicoCommentXmlParser"/>を初期化する
+        /// </summary>
+        /// <param name="socketFormat">ソケットを使うリアルタイムのデータ形式ならtrue 過去ログなどのデータ形式ならfalse</param>
+        public NiconicoCommentJsonParser(bool socketFormat)
+        {
+            this.socketFormat = socketFormat;
+        }
+
+        public void Push(string str)
+        {
+            if (socketFormat)
+            {
+               if (str.StartsWith("{\"chat"))
+               {
+                   chats.Enqueue(getChatJSONTag(str));
+               }
+            }
+            else
+            {
+                // サポートしない,
+            }
+        }
+
+        /// <summary>
+        /// 解析結果を返す <see cref="socketFormat"/>がfalseなら<see cref="ChatNiconicoCommentXmlTag"/>しか返さない
+        /// </summary>
+        /// <returns>解析結果の<see cref="NiconicoCommentXmlTag"/></returns>
+        public NiconicoCommentXmlTag Pop()
+        {
+            return chats.Dequeue();
+        }
+
+        /// <summary>
+        /// <see cref="Pop"/>で読みだすデータがあるか
+        /// </summary>
+        public bool DataAvailable()
+        {
+            return chats.Count > 0;
+        }
+
+        public void Reset()
+        {
+            buffer = string.Empty;
+            chats.Clear();
+        }
+
+        private static ChatNiconicoCommentXmlTag getChatJSONTag(string str) {
+            JObject jsonObj = JObject.Parse(str);
+            // {"chat":{"thread":"M.kk-tzPBrneGMsNfDNO1skg","no":45929,"vpos":6496293,"date":1616936565,"date_usec":664450,"mail":"184","user_id":"EvrCRqk2e04B-pYS7q44kVU5HR4","anonymity":1,"content":"結局SBの勝ちかいｗ"}}
+            int vpos = int.Parse(jsonObj["chat"]["vpos"].ToString());
+            long date = long.Parse(jsonObj["chat"]["date"].ToString());
+            int dateUsec = jsonObj["chat"]["date_usec"] == null ? 0 : int.Parse(jsonObj["chat"]["date_usec"].ToString());
+            string mail = jsonObj["chat"]["mail"] == null ? "" : jsonObj["chat"]["mail"].ToString();
+            string userId = jsonObj["chat"]["user_id"].ToString();
+            int premium = jsonObj["chat"]["premium"] == null ? 0 : int.Parse(jsonObj["chat"]["premium"].ToString());
+            int anonymity = jsonObj["chat"]["anonymity"] == null ? 0 : int.Parse(jsonObj["chat"]["anonymity"].ToString());
+            int abone = jsonObj["chat"]["abone"] == null ? 0 : int.Parse(jsonObj["chat"]["abone"].ToString());
+            string content = (string)jsonObj["chat"]["content"];
+            int no = int.Parse(jsonObj["chat"]["no"].ToString());
+            return new ChatNiconicoCommentXmlTag(
+                        content, 0, no, vpos, date, dateUsec, mail, userId, premium, anonymity, abone
+                    );
+        }
+    }
+}

--- a/TVTComment/TVTComment.csproj
+++ b/TVTComment/TVTComment.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="AttachedCommandBehavior" Version="2.0.0" />
     <PackageReference Include="CommonServiceLocator" Version="1.3.0" />
     <PackageReference Include="Microsoft.Xml.SgmlReader" Version="1.8.18" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Prism.Core" Version="6.3.0-pre1" />
     <PackageReference Include="Prism.Unity" Version="6.3.0-pre1" />
     <PackageReference Include="Prism.Wpf" Version="6.3.0-pre1" />


### PR DESCRIPTION
Newtonsoft.Jsonを導入し、ニコ実況のJSONWebSocketAPIに接続してコメントデータを取得するように改造しました。
※もともとのXMLベースのWebsocketAPIは死んだっぽくってTVTCommentが落ちまくりです。

C#のソースをいじるのは実は1億年ぶりです。実装は凄く雑かもしれないが一応当方の環境では問題なさそうです。
変なところもしあれば勝手に修正してくださいｍ
