### PR TITLE
任意の正規表現によるコメント改変 / NG ルールの実装

### DIFF
--- a/TVTComment/Model/ChatModRules/RegexNgChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RegexNgChatModRule.cs
@@ -1,0 +1,33 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace TVTComment.Model.ChatModRules
+{
+    internal class RegexNgChatModRule : IChatModRule
+    {
+        public string Description => $"正規表現をNG: \"{Regex}\"";
+        public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }
+        public string Regex { get; }
+        private Regex CompiledRegex { get; }
+
+        public RegexNgChatModRule(IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> targetChatCollectServiceEntries, string regex)
+        {
+            TargetChatCollectServiceEntries = targetChatCollectServiceEntries;
+
+            Regex = regex;
+            CompiledRegex = new Regex(regex, RegexOptions.Compiled);
+        }
+
+        public bool Modify(Chat chat)
+        {
+            if (CompiledRegex.Matches(chat.Text).Any())
+            {
+                chat.SetNg(true);
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/TVTComment/Model/ChatModRules/RemoveAnchorChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RemoveAnchorChatModRule.cs
@@ -6,7 +6,7 @@ namespace TVTComment.Model.ChatModRules
 {
     internal class RemoveAnchorChatModRule : IChatModRule
     {
-        private static readonly Regex AnchorPattern = new Regex(">>\\d+", RegexOptions.Compiled);
+        private static readonly Regex AnchorPattern = new Regex(@">>\d+([-,]\d+)?", RegexOptions.Compiled);
 
         public string Description => "アンカーを削除";
         public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }

--- a/TVTComment/Model/ChatModRules/RenderInfoAsCommentChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RenderInfoAsCommentChatModRule.cs
@@ -27,12 +27,22 @@ namespace TVTComment.Model.ChatModRules
             var type = int.Parse(match.Groups["type"].Value);
             var text = match.Groups["text"].Value;
 
-            // /info 8 第xx位にランクインしました
-            if (type == 8)
+            switch (type)
             {
-                chat.SetPosition(Chat.PositionType.Top);
-                chat.SetText(text);
-                return true;
+                // /info 2 1人（プレミアム1人）がコミュニティをフォローしました。
+                case 2:
+                    chat.SetPosition(Chat.PositionType.Top);
+                    chat.SetText(text);
+                    return true;
+                // /info 8 第xx位にランクインしました
+                case 8:
+                    chat.SetPosition(Chat.PositionType.Top);
+                    chat.SetText(text);
+                    return true;
+                default:
+                    chat.SetPosition(Chat.PositionType.Top);
+                    chat.SetText(text);
+                    return true;
             }
 
             return true;

--- a/TVTComment/Model/ChatModRules/RenderNicoadAsCommentChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/RenderNicoadAsCommentChatModRule.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace TVTComment.Model.ChatModRules
+{
+    internal class RenderNicoadAsCommentChatModRule : IChatModRule
+    {
+        private static readonly Regex Pattern = new Regex(@"^/nicoad \{""totalAdPoint"":\d+,""message"":""(?<message>.+)"",""version"":""1""\}$", RegexOptions.Compiled);
+
+        public string Description => "/nicoad コマンドを運営コメントとして描画";
+        public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }
+
+        public RenderNicoadAsCommentChatModRule(IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> targetChatCollectServiceEntries)
+        {
+            TargetChatCollectServiceEntries = targetChatCollectServiceEntries;
+        }
+
+        public bool Modify(Chat chat)
+        {
+            var match = Pattern.Match(chat.Text);
+            if (!match.Success)
+            {
+                return false;
+            }
+
+            // /nicoad {"totalAdPoint":4600,"message":"【広告貢献1位】xxxさんが3100ptニコニ広告しました","version":"1"}
+            var message = match.Groups["message"].Value;
+
+            chat.SetText(message);
+            chat.SetPosition(Chat.PositionType.Top);
+
+            return true;
+
+        }
+    }
+}

--- a/TVTComment/Model/ChatModRules/ReplaceRegexChatModRule.cs
+++ b/TVTComment/Model/ChatModRules/ReplaceRegexChatModRule.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+namespace TVTComment.Model.ChatModRules
+{
+    internal class ReplaceRegexChatModRule : IChatModRule
+    {
+        public string Description => $"正規表現を置換: \"{Regex}\" → \"{Replacement}\"";
+        public IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> TargetChatCollectServiceEntries { get; }
+        public string Regex { get; }
+        private Regex CompiledRegex { get; }
+        public string Replacement { get; }
+
+        public ReplaceRegexChatModRule(IEnumerable<ChatCollectServiceEntry.IChatCollectServiceEntry> targetChatCollectServiceEntries, string regex, string replacement)
+        {
+            TargetChatCollectServiceEntries = targetChatCollectServiceEntries;
+
+            Regex = regex;
+            CompiledRegex = new Regex(regex, RegexOptions.Compiled);
+            Replacement = replacement;
+        }
+
+        public bool Modify(Chat chat)
+        {
+            var newText = CompiledRegex.Replace(chat.Text, Replacement);
+            if (chat.Text == newText)
+            {
+                return false;
+            }
+
+            chat.SetText(newText);
+            return true;
+        }
+    }
+}

--- a/TVTComment/Model/ChatModule.cs
+++ b/TVTComment/Model/ChatModule.cs
@@ -35,6 +35,8 @@ namespace TVTComment.Model
         private readonly ObservableCollection<ChatModRuleEntry> chatModRules = new ObservableCollection<ChatModRuleEntry>();
         public ReadOnlyObservableCollection<ChatModRuleEntry> ChatModRules { get; }
 
+        private const string ReplaceRegexExpressionDelimiter = "@@@@@";
+
         public ChatModule(
             TVTCommentSettings settings, IEnumerable<ChatService.IChatService> chatServices,
             ChatCollectServiceModule collectServiceModule, IPCModule ipc, ChannelInformationModule channelInformationModule
@@ -186,6 +188,13 @@ namespace TVTComment.Model
                     case "RenderNicoadAsComment":
                         entry.ChatModRule = new ChatModRules.RenderNicoadAsCommentChatModRule(targetServices);
                         break;
+                    case "ReplaceRegex":
+                        var components2 = entity.Expression.Split(ReplaceRegexExpressionDelimiter, 2);
+                        entry.ChatModRule = new ChatModRules.ReplaceRegexChatModRule(targetServices, components2[0], components2[1]);
+                        break;
+                    case "RegexNg":
+                        entry.ChatModRule = new ChatModRules.RegexNgChatModRule(targetServices, entity.Expression);
+                        break;
                     default:
                         continue;
                 }
@@ -250,6 +259,14 @@ namespace TVTComment.Model
                         break;
                     case ChatModRules.RenderNicoadAsCommentChatModRule _:
                         entity.Type = "RenderNicoadAsComment";
+                        break;
+                    case ChatModRules.ReplaceRegexChatModRule replaceRegex:
+                        entity.Type = "ReplaceRegex";
+                        entity.Expression = $"{replaceRegex.Regex}{ReplaceRegexExpressionDelimiter}{replaceRegex.Replacement}";
+                        break;
+                    case ChatModRules.RegexNgChatModRule regexNg:
+                        entity.Type = "RegexNg";
+                        entity.Expression = regexNg.Regex;
                         break;
                     default:
                         throw new Exception();

--- a/TVTComment/Model/ChatModule.cs
+++ b/TVTComment/Model/ChatModule.cs
@@ -183,6 +183,9 @@ namespace TVTComment.Model
                             targetServices, Color.FromArgb(components[0], components[1], components[2], components[3])
                         );
                         break;
+                    case "RenderNicoadAsComment":
+                        entry.ChatModRule = new ChatModRules.RenderNicoadAsCommentChatModRule(targetServices);
+                        break;
                     default:
                         continue;
                 }
@@ -244,6 +247,9 @@ namespace TVTComment.Model
                         entity.Type = "SetColor";
                         Color color = setColor.Color;
                         entity.Expression = $"{color.A},{color.R},{color.G},{color.B}";
+                        break;
+                    case ChatModRules.RenderNicoadAsCommentChatModRule _:
+                        entity.Type = "RenderNicoadAsComment";
                         break;
                     default:
                         throw new Exception();

--- a/TVTComment/ViewModels/NgSettingWindowViewModel.cs
+++ b/TVTComment/ViewModels/NgSettingWindowViewModel.cs
@@ -73,6 +73,8 @@ namespace TVTComment.ViewModels
         public ReadOnlyObservableCollection<Contents.ChatModRuleListItemViewModel> Rules { get; private set; }
         public ObservableValue<int> SmallOnMultiLineRuleLineCount { get; } = new ObservableValue<int>(2);
         public ObservableValue<Color> SetColorRuleColor { get; } = new ObservableValue<Color>(Color.FromArgb(255, 255, 255));
+        public ObservableValue<string> ReplaceRegexPattern { get; } = new ObservableValue<string>("");
+        public ObservableValue<string> ReplaceRegexReplacement { get; } = new ObservableValue<string>("");
 
         public ICommand AddWordNgCommand { get; private set; }
         public ICommand AddUserNgCommand { get; private set; }
@@ -87,6 +89,8 @@ namespace TVTComment.ViewModels
         public ICommand AddRenderInfoAsCommentCommand { get; private set; }
         public ICommand AddSetColorRuleCommand { get; private set; }
         public ICommand AddRenderNicoadAsCommentCommand { get; private set; }
+        public ICommand AddReplaceRegexCommand { get; private set; }
+        public ICommand AddRegexNgCommand { get; private set; }
         public ICommand RemoveRuleCommand { get; private set; }
 
         public NgSettingWindowViewModel(Model.TVTComment model)
@@ -173,6 +177,16 @@ namespace TVTComment.ViewModels
             AddRenderNicoadAsCommentCommand = new DelegateCommand(() =>
             {
                 model.ChatModule.AddChatModRule(new Model.ChatModRules.RenderNicoadAsCommentChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
+            });
+
+            AddReplaceRegexCommand = new DelegateCommand(() =>
+            {
+                model.ChatModule.AddChatModRule(new Model.ChatModRules.ReplaceRegexChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value), ReplaceRegexPattern.Value, ReplaceRegexReplacement.Value));
+            });
+
+            AddRegexNgCommand = new DelegateCommand(() =>
+            {
+                model.ChatModule.AddChatModRule(new Model.ChatModRules.RegexNgChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value), NgText));
             });
 
             RemoveRuleCommand = new DelegateCommand(() =>

--- a/TVTComment/ViewModels/NgSettingWindowViewModel.cs
+++ b/TVTComment/ViewModels/NgSettingWindowViewModel.cs
@@ -86,6 +86,7 @@ namespace TVTComment.ViewModels
         public ICommand AddRenderEmotionAsCommentCommand { get; private set; }
         public ICommand AddRenderInfoAsCommentCommand { get; private set; }
         public ICommand AddSetColorRuleCommand { get; private set; }
+        public ICommand AddRenderNicoadAsCommentCommand { get; private set; }
         public ICommand RemoveRuleCommand { get; private set; }
 
         public NgSettingWindowViewModel(Model.TVTComment model)
@@ -167,6 +168,11 @@ namespace TVTComment.ViewModels
                     TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value),
                     SetColorRuleColor.Value
                 ));
+            });
+
+            AddRenderNicoadAsCommentCommand = new DelegateCommand(() =>
+            {
+                model.ChatModule.AddChatModRule(new Model.ChatModRules.RenderNicoadAsCommentChatModRule(TargetChatCollectServiceEntries.Where(x => x.IsSelected).Select(x => x.Value)));
             });
 
             RemoveRuleCommand = new DelegateCommand(() =>

--- a/TVTComment/Views/NgSettingWindow.xaml
+++ b/TVTComment/Views/NgSettingWindow.xaml
@@ -98,6 +98,7 @@
                             <Button Command="{Binding AddRemoveUrlCommand}">URL 削除</Button>
                             <Button Command="{Binding AddRenderEmotionAsCommentCommand}">/emotion をコメントとして描画</Button>
                             <Button Command="{Binding AddRenderInfoAsCommentCommand}">/info をコメントとして描画</Button>
+                            <Button Command="{Binding AddRenderNicoadAsCommentCommand}">/nicoad をコメントとして描画</Button>
                         </StackPanel>
                     </GroupBox>
                 </StackPanel>

--- a/TVTComment/Views/NgSettingWindow.xaml
+++ b/TVTComment/Views/NgSettingWindow.xaml
@@ -50,6 +50,7 @@
                             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                                 <Button Content="NGワード" Command="{Binding AddWordNgCommand}"/>
                                 <Button Content="NGユーザー" Command="{Binding AddUserNgCommand}"/>
+                                <Button Content="NG正規表現" Command="{Binding AddRegexNgCommand}"/>
                             </StackPanel>
                             <Button Content="色コメNG" Command="{Binding AddIroKomeNgCommand}"/>
                             <Button Content="上下コメNG" Command="{Binding AddJyougeKomeNgCommand}"/>
@@ -96,6 +97,17 @@
                             </Button>
                             <Button Command="{Binding AddRemoveAnchorCommand}">アンカー削除</Button>
                             <Button Command="{Binding AddRemoveUrlCommand}">URL 削除</Button>
+                            <Button Command="{Binding AddReplaceRegexCommand}" VerticalContentAlignment="Center">
+                                <TextBlock>
+                                    正規表現置換
+                                    <LineBreak/>
+                                    検索
+                                    <TextBox VerticalAlignment="Center" Width="150" Text="{Binding ReplaceRegexPattern.Value,UpdateSourceTrigger=PropertyChanged}"/>
+                                    <LineBreak/>
+                                    置換
+                                    <TextBox VerticalAlignment="Center" Width="150" Text="{Binding ReplaceRegexReplacement.Value,UpdateSourceTrigger=PropertyChanged}"/>
+                                </TextBlock>
+                            </Button>
                             <Button Command="{Binding AddRenderEmotionAsCommentCommand}">/emotion をコメントとして描画</Button>
                             <Button Command="{Binding AddRenderInfoAsCommentCommand}">/info をコメントとして描画</Button>
                             <Button Command="{Binding AddRenderNicoadAsCommentCommand}">/nicoad をコメントとして描画</Button>


### PR DESCRIPTION
お世話になっております。いくつかの修正と新たな ChatModRule の実装が主です。

- 連続するアンカーがマッチするように修正 https://github.com/silane/TVTComment/commit/e4b22a7a907aaff6e3c3ee3ea8abc2f85616d88c
以前私がコミットしたアンカー表記の除去ルールですが
`>>100-102` や `>>102,104` のように複数にアンカーしている場合にマッチしていなかったので正規表現を修正しました。

- `/info 2 <text>` コマンドに対応 https://github.com/silane/TVTComment/commit/6d813d82b2ec2bc61a64e411f63b727ca6f9b929
これも以前のコミットに遡りますが、新たに非公式コミュニティで放送中にユーザがコミュニティをフォローしたときの通知に対応しました。

- `/nicoad` (ニコニ広告) のメッセージを描画する ChatModRule を追加 https://github.com/silane/TVTComment/commit/40d447a0d07a3094fd09484b8bc0220dd4b2159d
新たにニコニ広告されたときの通知を上コメントに変換する ChatModRule を追加しました。

- 正規表現でNGにしたり置換したりする ChatModRule を追加 https://github.com/silane/TVTComment/commit/1607dc37bea9a3d1dd52c912f71bd82a76f89133
任意の正規表現を置換したり NG したりできるようにする ChatModRule を追加しました。

![image](https://user-images.githubusercontent.com/7302150/118592893-b4932980-b7e1-11eb-848b-742690d08d93.png)

(画像は @noriokun4649 さんバージョンです)